### PR TITLE
bug fix 44714

### DIFF
--- a/MozuAndroidInStoreAssistant/app/src/main/java/com/mozu/mozuandroidinstoreassistant/app/order/OrderFulfillmentMoveToPickupDialogFragment.java
+++ b/MozuAndroidInStoreAssistant/app/src/main/java/com/mozu/mozuandroidinstoreassistant/app/order/OrderFulfillmentMoveToPickupDialogFragment.java
@@ -41,6 +41,7 @@ import rx.android.observables.AndroidObservable;
 public class OrderFulfillmentMoveToPickupDialogFragment extends DialogFragment implements OrderFulfillmentMoveToItemAdapter.MoveToListListener {
 
     private static final String FULFILLED = "fulfilled";
+    private static final String SELECTED = "selected";
     @InjectView(R.id.items)
     RecyclerView mRecyclerViewProducts;
     @InjectView(R.id.cancel)
@@ -58,7 +59,7 @@ public class OrderFulfillmentMoveToPickupDialogFragment extends DialogFragment i
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
-            selected = savedInstanceState.getIntegerArrayList("selected");
+            selected = savedInstanceState.getIntegerArrayList(SELECTED);
         }
         setRetainInstance(true);
 
@@ -77,22 +78,6 @@ public class OrderFulfillmentMoveToPickupDialogFragment extends DialogFragment i
         View view = inflater.inflate(R.layout.fulfillment_move_to, container, false);
         ButterKnife.inject(this, view);
         return view;
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        if (selected != null && !selected.isEmpty()) {
-            outState.putIntegerArrayList("selected", selected);
-        }
-        super.onSaveInstanceState(outState);
-
-    }
-
-    @Override
-    public void onDestroyView() {
-        if (getDialog() != null && getRetainInstance())
-            getDialog().setDismissMessage(null);
-        super.onDestroyView();
     }
 
     @Override
@@ -145,6 +130,22 @@ public class OrderFulfillmentMoveToPickupDialogFragment extends DialogFragment i
             }
 
         });
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (selected != null && !selected.isEmpty()) {
+            outState.putIntegerArrayList(SELECTED, selected);
+        }
+        super.onSaveInstanceState(outState);
+
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (getDialog() != null && getRetainInstance())
+            getDialog().setDismissMessage(null);
+        super.onDestroyView();
     }
 
     public void createNewPickUps() {

--- a/MozuAndroidInStoreAssistant/app/src/main/java/com/mozu/mozuandroidinstoreassistant/app/order/adapters/OrderFulfillmentMoveToItemAdapter.java
+++ b/MozuAndroidInStoreAssistant/app/src/main/java/com/mozu/mozuandroidinstoreassistant/app/order/adapters/OrderFulfillmentMoveToItemAdapter.java
@@ -1,7 +1,6 @@
 package com.mozu.mozuandroidinstoreassistant.app.order.adapters;
 
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +9,7 @@ import android.widget.TextView;
 import com.mozu.api.contracts.commerceruntime.orders.OrderItem;
 import com.mozu.mozuandroidinstoreassistant.app.R;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.ButterKnife;
@@ -19,6 +19,7 @@ public class OrderFulfillmentMoveToItemAdapter extends RecyclerView.Adapter<Orde
 
     List<OrderItem> mData;
     MoveToListListener mListener;
+    private ArrayList<Integer> mSelected;
 
     public OrderFulfillmentMoveToItemAdapter(List<OrderItem> mData, MoveToListListener mListener) {
         this.mData = mData;
@@ -33,6 +34,11 @@ public class OrderFulfillmentMoveToItemAdapter extends RecyclerView.Adapter<Orde
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
+        if (mSelected != null && !mSelected.isEmpty()) {
+            if (mSelected.contains(position)) {
+                holder.itemView.setActivated(true);
+            }
+        }
         OrderItem item = mData.get(position);
         holder.code.setText(item.getProduct().getProductCode());
         holder.product.setText(item.getProduct().getName());
@@ -43,6 +49,10 @@ public class OrderFulfillmentMoveToItemAdapter extends RecyclerView.Adapter<Orde
     @Override
     public int getItemCount() {
         return mData.size();
+    }
+
+    public void setSelected(ArrayList<Integer> selected) {
+        mSelected = selected;
     }
 
     public interface MoveToListListener {
@@ -68,7 +78,6 @@ public class OrderFulfillmentMoveToItemAdapter extends RecyclerView.Adapter<Orde
 
         @Override
         public void onClick(View itemView) {
-            Log.d("intellij", "");
             itemView.setActivated(!itemView.isActivated());
             mListener.onItemSelected(getAdapterPosition(), itemView.isActivated());
         }


### PR DESCRIPTION
if a user selected a package with no items selected the selection will revert to "Move To"
fixed dialog rotation to retain instance.
